### PR TITLE
fix: black screen appears after scenario creation when there is no scenario

### DIFF
--- a/src/PowerBI/PowerBIUtils.js
+++ b/src/PowerBI/PowerBIUtils.js
@@ -19,6 +19,11 @@ function constructDynamicValue (filterValue, objectToFilter) {
 
 const constructDynamicFilters = (filtersConfig, objectToFilter) => {
   const result = [];
+
+  if (!objectToFilter) {
+    return result;
+  }
+
   for (const filterConfig of filtersConfig) {
     const filterValues = filterConfig.values;
     let filter;
@@ -47,21 +52,22 @@ const constructDynamicFilters = (filtersConfig, objectToFilter) => {
 };
 
 const constructScenarioDTO = (scenario) => {
-  let result;
+  if (!scenario) {
+    return null;
+  }
+
   let csmSimRun = scenario?.lastRun?.csmSimulationRun === undefined
-    ? null
-    : scenario?.lastRun?.csmSimulationRun;
-  if (scenario !== undefined) {
-    result = new ScenarioDTO(scenario.id,
+      ? null
+      : scenario?.lastRun?.csmSimulationRun;
+
+  return new ScenarioDTO(scenario.id,
       scenario.name,
       scenario.state,
       csmSimRun,
       scenario.rootId,
       scenario.parentId,
       scenario.ownerId,
-      scenario.solutionId)
-  }
-  return result;
+      scenario.solutionId);
 }
 
 


### PR DESCRIPTION
Handle correctly null and undefined in constructDynamicFilters and constructScenarioDTO functions